### PR TITLE
Add daily values line chart

### DIFF
--- a/src/components/declarations/dossier/prelevements/daily-values-chart.js
+++ b/src/components/declarations/dossier/prelevements/daily-values-chart.js
@@ -1,0 +1,54 @@
+'use client'
+
+import {Box, Divider} from '@mui/material'
+import {LineChart} from '@mui/x-charts'
+import {format, parseISO} from 'date-fns'
+import {fr} from 'date-fns/locale'
+
+const DailyValuesChart = ({data}) => {
+  const {dailyValues = [], dailyParameters = []} = data || {}
+  if (dailyValues.length === 0 || dailyParameters.length === 0) {
+    return null
+  }
+
+  const xData = dailyValues.map(entry => parseISO(entry.date))
+
+  const series = dailyParameters.map((param, idx) => ({
+    id: param.nom_parametre,
+    label: `${param.nom_parametre} (${param.unite})`,
+    data: dailyValues.map(entry => entry.values[idx]),
+    showMark: false,
+    curve: 'linear',
+    valueFormatter: value =>
+      value === null ? 'Aucune donnée' : `${value} ${param.unite}`
+  }))
+
+  return (
+    <Box className='flex flex-col gap-4 mt-4'>
+      <Divider textAlign='left'>Graphique des données journalières</Divider>
+      <LineChart
+        series={series}
+        xAxis={[{
+          scaleType: 'time',
+          data: xData,
+          valueFormatter: value => format(value, 'd MMM', {locale: fr})
+        }]}
+        height={300}
+        margin={{
+          left: 60,
+          right: 30,
+          top: 20,
+          bottom: 60
+        }}
+        slotProps={{
+          legend: {
+            direction: 'row',
+            position: {vertical: 'top', horizontal: 'right'}
+          }
+        }}
+      />
+    </Box>
+  )
+}
+
+export default DailyValuesChart

--- a/src/components/declarations/dossier/prelevements/spreadsheet.js
+++ b/src/components/declarations/dossier/prelevements/spreadsheet.js
@@ -8,6 +8,7 @@ import {
   Typography, Alert
 } from '@mui/material'
 
+import DailyValuesChart from '@/components/declarations/dossier/prelevements/daily-values-chart.js'
 import FileValidationErrors from '@/components/declarations/file-validation-errors.js'
 import PrelevementsCalendar from '@/components/declarations/prelevements-calendar.js'
 
@@ -76,6 +77,7 @@ const Spreadsheet = ({moisDeclaration, file, downloadFile}) => {
             )}
 
             <PrelevementsCalendar data={file.result.data} />
+            <DailyValuesChart data={file.result.data} />
           </Box>
         </>
       )}


### PR DESCRIPTION
## Summary
- show a line chart for daily values
- display the chart below the monthly calendar

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_b_6851a44042948324913a9ac5a2950179